### PR TITLE
compatibilidade com 1.9

### DIFF
--- a/lib/faker/cnpj.rb
+++ b/lib/faker/cnpj.rb
@@ -26,7 +26,7 @@ module Faker
         end
 
         second_validator = sum % 11
-        (cnpj_root << second_validator = second_validator < 2 ? 0 : 11 - second_validator).to_s
+        (cnpj_root << second_validator = second_validator < 2 ? 0 : 11 - second_validator).join
       end
       alias numbers numeric
       alias number numeric

--- a/lib/faker/cpf.rb
+++ b/lib/faker/cpf.rb
@@ -27,7 +27,7 @@ module Faker
 
         second_validator = sum % 11
         second_validator = second_validator < 2 ? 0 : 11 - second_validator
-        (cpf_root << second_validator).to_s
+        (cpf_root << second_validator).join
       end
       alias number numeric
       alias numbers numeric


### PR DESCRIPTION
no 1.9 to_s age de forma parecida com inspect, no caso de um array fica assim

>> [1,2,3,4].to_s

=> "[1, 2, 3, 4]"

trocando por join fica OK tanto no 1.9.2 quanto no 1.8.7
